### PR TITLE
Copy source files into the container

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -9,3 +9,6 @@ RUN a2enmod rewrite
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions pdo_mysql
+
+# Compose overrides this with a bind mount for easy dev.
+COPY ./ /srv/www/

--- a/apache/compose.yaml
+++ b/apache/compose.yaml
@@ -1,8 +1,9 @@
 services:
   apache:
     build:
-      context: ./docker/apache
+      context: .
     volumes:
+      # Use a bind mount for easy development.
       - ./:/srv/www
     ports:
       - 80:80

--- a/apache/stack.yaml
+++ b/apache/stack.yaml
@@ -3,8 +3,9 @@ services:
   apache:
     # This is the same compose image but pushed to ghcr.
     image: ghcr.io/tuupola/apache-php-example
-    volumes:
-      - ./:/srv/www
+    # Uncomment this if you want to dev with swarm.
+    # volumes:
+    #   - ./:/srv/www
     ports:
       - 80:80
     deploy:

--- a/caddy-apache/Dockerfile
+++ b/caddy-apache/Dockerfile
@@ -9,3 +9,6 @@ RUN a2enmod rewrite
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions pdo_mysql
+
+# Compose overrides this with a bind mount for easy dev.
+COPY ./ /srv/www/

--- a/caddy-apache/compose.yaml
+++ b/caddy-apache/compose.yaml
@@ -8,8 +8,9 @@ services:
     command: caddy reverse-proxy --from example.localhost --to apache
   apache:
     build:
-      context: ./docker/apache
+      context: .
     volumes:
+      # Use a bind mount for easy development.
       - ./:/srv/www
   mariadb:
     image: mariadb:latest

--- a/caddy-apache/stack.yaml
+++ b/caddy-apache/stack.yaml
@@ -15,8 +15,9 @@ services:
   apache:
     # This is the same compose image but pushed to ghcr.
     image: ghcr.io/tuupola/apache-php-example
-    volumes:
-      - ./:/srv/www
+    # Uncomment this if you want to dev with swarm.
+    # volumes:
+    #   - ./:/srv/www
     deploy:
       replicas: 3
       # Do not create Docker virtual IP endpoint since Caddy is used

--- a/caddy-phpfpm/Dockerfile
+++ b/caddy-phpfpm/Dockerfile
@@ -3,3 +3,6 @@ WORKDIR /srv/www
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions pdo_mysql
+
+# Compose overrides this with a bind mount for easy dev.
+COPY ./ /srv/www/

--- a/caddy-phpfpm/compose.yaml
+++ b/caddy-phpfpm/compose.yaml
@@ -10,7 +10,7 @@ services:
       - .:/srv/www
   fpm:
     build:
-      context: ./docker/fpm
+      context: .
     volumes:
       - ./:/srv/www
   mariadb:

--- a/caddy-phpfpm/stack.yaml
+++ b/caddy-phpfpm/stack.yaml
@@ -15,8 +15,9 @@ services:
       - CADDY_INGRESS_NETWORKS=slim_default
   fpm:
     image: ghcr.io/tuupola/php-fpm-example
-    volumes:
-      - ./:/srv/www
+    # Uncomment this if you want to dev with swarm.
+    # volumes:
+    #   - ./:/srv/www
     deploy:
       replicas: 3
       # Do not create Docker virtual IP endpoint since Caddy is used

--- a/nginx-phpfpm/Dockerfile
+++ b/nginx-phpfpm/Dockerfile
@@ -3,3 +3,6 @@ WORKDIR /srv/www
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions pdo_mysql
+
+# Compose overrides this with a bind mount for easy dev.
+COPY ./ /srv/www/

--- a/nginx-phpfpm/compose.yaml
+++ b/nginx-phpfpm/compose.yaml
@@ -9,7 +9,7 @@ services:
       - 443:443
   fpm:
     build:
-      context: ./docker/fpm
+      context: .
     volumes:
       - ./:/srv/www
   mariadb:

--- a/nginx-phpfpm/stack.yaml
+++ b/nginx-phpfpm/stack.yaml
@@ -10,8 +10,9 @@ services:
       - 443:443
   fpm:
     image: ghcr.io/tuupola/php-fpm-example
-    volumes:
-      - ./:/srv/www
+    # Uncomment this if you want to dev with swarm.
+    # volumes:
+    #   - ./:/srv/www
     deploy:
       replicas: 3
   mariadb:

--- a/traefik-apache/Dockerfile
+++ b/traefik-apache/Dockerfile
@@ -9,3 +9,6 @@ RUN a2enmod rewrite
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions pdo_mysql
+
+# Compose overrides this with a bind mount for easy dev.
+COPY ./ /srv/www/

--- a/traefik-apache/compose.yaml
+++ b/traefik-apache/compose.yaml
@@ -25,7 +25,7 @@ services:
       - traefik.http.routers.traefik.tls=true
   apache:
     build:
-      context: ./docker/apache
+      context: .
     volumes:
       - ./:/srv/www
     labels:

--- a/traefik-apache/stack.yaml
+++ b/traefik-apache/stack.yaml
@@ -31,8 +31,9 @@ services:
   apache:
     # This is the same compose image but pushed to ghcr.
     image: ghcr.io/tuupola/apache-php-example
-    volumes:
-      - ./:/srv/www
+    # Uncomment this if you want to dev with swarm.
+    # volumes:
+    #   - ./:/srv/www
     deploy:
       replicas: 3
       # Do not create Docker virtual IP endpoint since Traefik is used


### PR DESCRIPTION
More production like setup for stacks. Development can still bind mount the source folder. Dockerfile needs to be moved to project root or COPY does not work.