### PR TITLE
Copy PHP files also to the NGINX container

### DIFF
--- a/nginx-phpfpm/README.md
+++ b/nginx-phpfpm/README.md
@@ -11,15 +11,13 @@ $ composer install
 You can either run with docker compose for development.
 
 ```
-$ docker compose build
-$ docker compose up
+$ docker compose up --build
 ```
 
 Or as a docker stack which is a more production like setup. The stack has three instances of PHP 8.1 as PHP-FPM reverse proxied by NGINX load balanced by the swarm routing mesh. Single MariaDB instance also in the swarm
 
 ```
 $ docker swarm init
-$ docker compose build
 $ docker stack deploy -c stack.yaml slim
 ```
 

--- a/nginx-phpfpm/compose.yaml
+++ b/nginx-phpfpm/compose.yaml
@@ -1,6 +1,9 @@
 services:
   nginx:
-    image: nginx:alpine
+    image: ghcr.io/tuupola/nginx-php-example
+    build:
+      context: .
+      dockerfile: ./docker/nginx/Dockerfile
     volumes:
       - ./:/srv/www
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf

--- a/nginx-phpfpm/docker/nginx/Dockerfile
+++ b/nginx-phpfpm/docker/nginx/Dockerfile
@@ -1,0 +1,11 @@
+# This is used with docker compose. The image has also been pushed
+# to GitHub Container Registry.
+#
+# $ docker pull ghcr.io/tuupola/nginx-php-example
+
+FROM nginx:alpine
+WORKDIR /srv/www
+
+# Compose overrides these with a bind mount for easy dev.
+COPY ./ /srv/www/
+COPY ./docker/nginx/default.conf /etc/nginx/conf.d/default.conf

--- a/nginx-phpfpm/stack.yaml
+++ b/nginx-phpfpm/stack.yaml
@@ -1,10 +1,11 @@
 version: "3.9"
 services:
   nginx:
-    image: nginx:alpine
-    volumes:
-      - ./:/srv/www
-      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+    image: ghcr.io/tuupola/nginx-php-example
+    # Uncomment this if you want to dev with swarm.
+    # volumes:
+    #   - ./:/srv/www
+    #   - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
Both nginx and php-fpm need the same file structure. This way
the stack does not need bind mounts.